### PR TITLE
feat(config): initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.kotlin
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="2.2.10" />
+  </component>
+</project>

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -2,6 +2,16 @@ plugins {
     `maven-publish`
 }
 
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    api("com.akuleshov7:ktoml-core:0.7.1")
+    api("com.akuleshov7:ktoml-file:0.7.1")
+}
+
 publishing {
     repositories {
         maven {

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/KittiAPI.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/KittiAPI.kt
@@ -1,6 +1,6 @@
 package net.sylviameows.kitti.api
 
-import org.jetbrains.annotations.ApiStatus.Internal
+import org.jetbrains.annotations.ApiStatus
 
 interface KittiAPI {
     companion object {
@@ -9,7 +9,7 @@ interface KittiAPI {
         }
     }
 
-    @Internal
+    @ApiStatus.Internal
     object Holder {
         internal lateinit var INSTANCE: KittiAPI;
 

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/KittiAPI.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/KittiAPI.kt
@@ -1,5 +1,7 @@
 package net.sylviameows.kitti.api
 
+import net.sylviameows.kitti.api.config.ConfigManager
+import org.bukkit.plugin.java.JavaPlugin
 import org.jetbrains.annotations.ApiStatus
 
 interface KittiAPI {
@@ -7,7 +9,13 @@ interface KittiAPI {
         fun instance(): KittiAPI {
             return Holder.INSTANCE
         }
+
+        fun getConfigManager(plugin: JavaPlugin): ConfigManager {
+            return instance().getConfigManager(plugin);
+        }
     }
+
+    fun getConfigManager(plugin: JavaPlugin): ConfigManager;
 
     @ApiStatus.Internal
     object Holder {

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/config/ConfigManager.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/config/ConfigManager.kt
@@ -1,0 +1,9 @@
+package net.sylviameows.kitti.api.config
+
+interface ConfigManager {
+    fun <T> load(path: String, clazz: Class<T>): KittiConfig<T>
+}
+
+inline fun <reified T> ConfigManager.load(path: String): KittiConfig<T> {
+    return this.load(path, T::class.java);
+}

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/config/KittiConfig.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/config/KittiConfig.kt
@@ -1,0 +1,14 @@
+package net.sylviameows.kitti.api.config
+
+import com.akuleshov7.ktoml.file.TomlFileWriter
+import kotlinx.serialization.serializer
+
+class KittiConfig<T> (val values: T, private val path: String) {
+    fun save() {
+        TomlFileWriter().encodeToFile(serializer(values!!::class.java), values, path);
+    }
+
+    fun values(): T {
+        return values;
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.1.20"
+    kotlin("jvm") version "2.2.10"
 }
 
 group = "net.sylviameows"
@@ -8,17 +8,20 @@ version = properties["plugin_version"] ?: "unspecified"
 ext {
     set("plugin_id", properties["plugin_id"])
     set("plugin_version", properties["plugin_version"])
+    set("minecraft_version", properties["minecraft_version"])
+}
 
-    set("api_version", properties["api_version"])
-    set("paper_version", properties["paper_version"])
+repositories {
+    mavenCentral()
 }
 
 allprojects {
     apply(plugin = "kotlin")
 
-    repositories {
-        mavenCentral()
+    group = rootProject.group
+    version = rootProject.version
 
+    repositories {
         maven {
             name = "papermc"
             url = uri("https://repo.papermc.io/repository/maven-public/")
@@ -26,12 +29,8 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("io.papermc.paper:paper-api:${rootProject.ext["paper_version"]}")
+        compileOnly("io.papermc.paper:paper-api:${properties["minecraft_version"]}-R0.1-SNAPSHOT")
     }
-
-    group = rootProject.group
-    version = rootProject.version
-
 //    apply(plugin = "checkstyle")
 
 //    checkstyle {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "9.0.2"
 }
 
 repositories {
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    shadow("org.jetbrains.kotlin:kotlin-stdlib:2.1.20")
+    shadow("org.jetbrains.kotlin:kotlin-stdlib:2.2.10")
     implementation(project(":KittiAPI"))
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    kotlin("plugin.serialization") version "2.2.10"
     id("com.gradleup.shadow") version "9.0.2"
 }
 

--- a/core/src/main/kotlin/net/sylviameows/kitti/Core.kt
+++ b/core/src/main/kotlin/net/sylviameows/kitti/Core.kt
@@ -2,6 +2,8 @@ package net.sylviameows.kitti
 
 import io.papermc.paper.plugin.configuration.PluginMeta
 import net.sylviameows.kitti.api.KittiAPI
+import net.sylviameows.kitti.api.config.ConfigManager
+import net.sylviameows.kitti.config.KittiConfigManager
 import org.bukkit.plugin.java.JavaPlugin
 
 class Core : KittiAPI, JavaPlugin() {
@@ -13,5 +15,16 @@ class Core : KittiAPI, JavaPlugin() {
         logger.info("KittiLib initialized.")
 
         META = pluginMeta
+    }
+
+    private val configManagers: MutableMap<String, ConfigManager> = HashMap()
+    override fun getConfigManager(plugin: JavaPlugin): ConfigManager {
+        if (configManagers.containsKey(plugin.name)) {
+            return configManagers[plugin.name]!!
+        }
+
+        val manager = KittiConfigManager(plugin);
+        configManagers[plugin.name] = manager;
+        return manager;
     }
 }

--- a/core/src/main/kotlin/net/sylviameows/kitti/config/KittiConfigManager.kt
+++ b/core/src/main/kotlin/net/sylviameows/kitti/config/KittiConfigManager.kt
@@ -1,0 +1,45 @@
+package net.sylviameows.kitti.config
+
+import com.akuleshov7.ktoml.file.TomlFileReader
+import com.akuleshov7.ktoml.file.TomlFileWriter
+import kotlinx.serialization.serializer
+import net.sylviameows.kitti.api.config.ConfigManager
+import net.sylviameows.kitti.api.config.KittiConfig
+import org.bukkit.plugin.java.JavaPlugin
+import java.io.File
+
+class KittiConfigManager(private val plugin: JavaPlugin) : ConfigManager {
+    private val loadedConfigs = mutableMapOf<String, KittiConfig<*>>()
+
+    override fun <T> load(path: String, clazz: Class<T>): KittiConfig<T> {
+        val path = plugin.dataFolder.path+"/$path.toml"
+
+        if (loadedConfigs.containsKey(path)) {
+            val config = loadedConfigs[path]!!;
+            if (clazz.isInstance(config.values)) {
+                @Suppress("UNCHECKED_CAST")
+                return config as KittiConfig<T>;
+            }
+            throw IllegalArgumentException("Does not match type.")
+        }
+
+        val file = File(path);
+        var instance: Any;
+        if (file.exists()) {
+            instance = TomlFileReader().decodeFromFile(serializer(clazz), path);
+        } else {
+            val constructor = clazz.getConstructor()
+                ?: throw IllegalArgumentException("type ${clazz.name} must have an empty constructor!");
+            constructor.isAccessible = true;
+
+            instance = constructor.newInstance() as Any;
+            TomlFileWriter().encodeToFile(serializer(clazz), instance as Any, path);
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val config = KittiConfig(instance as T, path);
+
+        loadedConfigs[path] = config;
+        return config
+    }
+}

--- a/core/src/main/resources/paper-plugin.yml
+++ b/core/src/main/resources/paper-plugin.yml
@@ -2,7 +2,7 @@ name: $plugin_id
 description: "Plugin Library for sylviameows' plugins."
 
 version: $plugin_version
-api-version: $api_version
+api-version: $minecraft_version
 
 main: net.sylviameows.kitti.Core
 bootstrapper: net.sylviameows.kitti.Bootstrap

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,7 @@ kotlin.code.style=official
 
 plugin_id=KittiLib
 plugin_version=0.3.1
-api_version=1.21.5
+
+minecraft_version=1.21.5
 
 author=sylviameows
-
-paper_version=1.21.4-R0.1-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 plugin_id=KittiLib
-plugin_version=0.3.1
+plugin_version=0.4.0
 
 minecraft_version=1.21.5
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun May 11 21:32:44 CDT 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Changes
- Kitti now uses ktoml for simple typesafe configs in **toml**.
- Added ConfigManager class that can be obtained by running `KittiAPI.getConfigManager(plugin)`.

## How to Use
When using the configuration feature of Kitti, you must include the serialization plugin in your buildscript as seen below.
```kts
plugins {
    kotlin("plugin.serialization") version "2.2.10"
}
```
Configs are data classes given the `@Serializable` annotation as seen below.
```kt
@Serializable
data class TestConfig(
    var host: String = "0.0.0.0",
    var port: Int = 2150,
    @TomlComments("Do not share this with anybody!")
    var auth: Authentication = Authentication("admin", "password123"),
)

@Serializable
data class Authentication(
    @SerialName("username")
    var user: String,
    @SerialName("password")
    var pass: String,
)
```

Here is an example of how you can use this config.
```kt
override fun onEnable() {
    val cm = KittiAPI.getConfigManager(this)
    val config: KittiConfig<TestConfig> = cm.load<TestConfig>("config" /* this is your config path, excluding file extension */)
    
    // Prints "0.0.0.0", or if the config has been modified the set value.
    getLogger().info(config.values.host)
    
    config.values.host = "1.1.1.1" // changes the host, does not save until you run KittiConfig#save()
    config.save()
}
```

## Whats missing?
Currently there is no migration support, so changing configs may cause issues with loading. Hoping to address this in a future PR.