### PR TITLE
feat(context): make context instance extendable

### DIFF
--- a/api/src/main/kotlin/net/sylviameows/kitti/api/KittiBootstrapper.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/KittiBootstrapper.kt
@@ -3,17 +3,28 @@ package net.sylviameows.kitti.api
 import io.papermc.paper.command.brigadier.Commands
 import io.papermc.paper.plugin.bootstrap.BootstrapContext
 import io.papermc.paper.plugin.bootstrap.PluginBootstrap
+import io.papermc.paper.plugin.bootstrap.PluginProviderContext
 import io.papermc.paper.plugin.lifecycle.event.registrar.ReloadableRegistrarEvent
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
-import net.sylviameows.kitti.api.commands.Command
+import net.sylviameows.kitti.api.commands.RawCommand
+import net.sylviameows.kitti.api.commands.context.Context
+import net.sylviameows.kitti.api.commands.context.ContextProvider
+import net.sylviameows.kitti.api.commands.context.StandardContextProvider
+import org.bukkit.plugin.java.JavaPlugin
 
-abstract class KittiBootstrapper : PluginBootstrap {
-    private val commandsList: MutableList<Command> = ArrayList();
+@Suppress("UnstableApiUsage")
+abstract class KittiBootstrapper<Plugin : JavaPlugin> : PluginBootstrap {
+    private val commandsList: MutableList<RawCommand<Plugin, Context<Plugin>>> = ArrayList();
+    protected val contextProvider = initContextProvider();
 
-    protected fun addCommand(command: Command) {
+    protected fun initContextProvider(): ContextProvider<Plugin, Context<Plugin>> {
+        return StandardContextProvider();
+    }
+
+    protected fun addCommand(command: RawCommand<Plugin, Context<Plugin>>) {
         commandsList.add(command);
     }
-    protected fun addCommands(vararg commands: Command) {
+    protected fun addCommands(vararg commands: RawCommand<Plugin, Context<Plugin>>) {
         commands.forEach(this::addCommand)
     }
 
@@ -29,8 +40,15 @@ abstract class KittiBootstrapper : PluginBootstrap {
         val registrar = event.registrar();
 
         this.commandsList.forEach { command ->
-            registrar.register(command.build())
+            registrar.register(command.build(contextProvider))
         }
     }
 
+    override fun createPlugin(context: PluginProviderContext): JavaPlugin {
+        val plugin = plugin(context)
+        contextProvider.plugin = plugin;
+        return plugin;
+    }
+
+    abstract fun plugin(context: PluginProviderContext): Plugin;
 }

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/commands/Command.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/commands/Command.kt
@@ -1,22 +1,10 @@
 package net.sylviameows.kitti.api.commands
 
-import com.mojang.brigadier.tree.LiteralCommandNode
-import io.papermc.paper.command.brigadier.CommandSourceStack
+import net.sylviameows.kitti.api.commands.context.Context
+import org.bukkit.plugin.java.JavaPlugin
 
-interface Command {
-    val name: String
-
-    private fun options(): Options {
-        return options(Options.from(this));
-    }
-
-    fun options(options: Options): Options {
-        return options;
-    }
-
-    fun execute(context: Context): Result
-
-    fun build(): LiteralCommandNode<CommandSourceStack> {
-        return options().build();
-    }
-}
+/**
+ * Alias for using default Context in your commands, use RawCommand if using a custom Context instance.
+ * @see RawCommand
+ */
+interface Command<Plugin : JavaPlugin> : RawCommand<Plugin, Context<Plugin>> {}

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/commands/RawCommand.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/commands/RawCommand.kt
@@ -1,0 +1,31 @@
+package net.sylviameows.kitti.api.commands
+
+import com.mojang.brigadier.tree.LiteralCommandNode
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import net.sylviameows.kitti.api.commands.context.Context
+import net.sylviameows.kitti.api.commands.context.ContextProvider
+import net.sylviameows.kitti.api.commands.Options
+import org.bukkit.plugin.java.JavaPlugin
+
+/**
+ * Raw typed command, best used if using a custom Context type for your plugin.
+ * This type is not recommended for standard use cases, reference Command<Plugin>.
+ * @see Command
+ */
+interface RawCommand<Plugin : JavaPlugin, C : Context<Plugin>> {
+    val name: String
+
+    private fun options(): Options {
+        return options(Options.from(this));
+    }
+
+    fun options(options: Options): Options {
+        return options;
+    }
+
+    fun execute(context: C): Result
+
+    fun build(provider: ContextProvider<Plugin, C>): LiteralCommandNode<CommandSourceStack> {
+        return options().build(provider);
+    }
+}

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/Context.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/Context.kt
@@ -1,14 +1,18 @@
-package net.sylviameows.kitti.api.commands
+package net.sylviameows.kitti.api.commands.context
 
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import net.sylviameows.kitti.api.commands.exceptions.ContextNullException
 import net.sylviameows.kitti.api.commands.exceptions.ContextTypeException
-import org.jetbrains.annotations.ApiStatus.Internal
-import kotlin.jvm.Throws
+import org.bukkit.plugin.java.JavaPlugin
+import org.jetbrains.annotations.ApiStatus
 
-class Context private constructor(
+/**
+ * The standard context instance. Contains the commands argument data, plugin,
+ */
+class Context<Plugin : JavaPlugin> private constructor(
     val arguments: Map<String, Any?>,
     val source: CommandSourceStack,
+    val plugin: Plugin,
     val subcommand: String?
 ) {
     val count: Int
@@ -41,23 +45,23 @@ class Context private constructor(
         return get<T>(key) ?: throw ContextNullException(key);
     }
 
-    @Internal
-    class Builder {
+    @ApiStatus.Internal
+    class Builder<Plugin : JavaPlugin> : ContextBuilder {
         private val arguments: MutableMap<String, Any> = HashMap();
         private var subcommand: String? = null;
 
-        fun set(key: String, value: Any): Builder {
+        override fun set(key: String, value: Any): Builder<Plugin> {
             arguments[key] = value
             return this;
         }
 
-        fun subcommand(subcommand: String): Builder {
+        override fun subcommand(subcommand: String): Builder<Plugin> {
             this.subcommand = subcommand;
             return this;
         }
 
-        fun build(source: CommandSourceStack): Context {
-            return Context(arguments.toMap(), source, subcommand)
+        fun build(source: CommandSourceStack, plugin: Plugin): Context<Plugin> {
+            return Context(arguments.toMap(), source, plugin, subcommand)
         }
     }
 }

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/ContextBuilder.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/ContextBuilder.kt
@@ -1,0 +1,6 @@
+package net.sylviameows.kitti.api.commands.context
+
+interface ContextBuilder {
+    fun set(key: String, value: Any): ContextBuilder
+    fun subcommand(subcommand: String): ContextBuilder
+}

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/ContextProvider.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/ContextProvider.kt
@@ -1,0 +1,31 @@
+package net.sylviameows.kitti.api.commands.context
+
+import com.mojang.brigadier.context.CommandContext
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import net.sylviameows.kitti.api.commands.Argument
+import org.bukkit.plugin.java.JavaPlugin
+
+
+abstract class ContextProvider<Plugin : JavaPlugin, C : Context<Plugin>> {
+    lateinit var plugin: Plugin;
+
+    abstract fun create(
+        ctx: CommandContext<CommandSourceStack>,
+        arguments: MutableList<Argument<*>>,
+        subcommand: String? = null
+    ): C
+
+    fun process(builder: ContextBuilder, ctx: CommandContext<CommandSourceStack>, arguments: MutableList<Argument<*>>, subcommand: String?) {
+        if (!subcommand.isNullOrEmpty()) builder.subcommand(subcommand)
+
+        arguments.forEachIndexed { index, argument ->
+            try {
+                val name = argument.name ?: "arg$index"
+                val value = ctx.getArgument(name, argument.resultType);
+                if (value != null) builder.set(name, value)
+            } catch (_: IllegalArgumentException) {
+
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/StandardContextProvider.kt
+++ b/api/src/main/kotlin/net/sylviameows/kitti/api/commands/context/StandardContextProvider.kt
@@ -1,0 +1,20 @@
+package net.sylviameows.kitti.api.commands.context
+
+import com.mojang.brigadier.context.CommandContext
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import net.sylviameows.kitti.api.commands.Argument
+import org.bukkit.plugin.java.JavaPlugin
+
+class StandardContextProvider<Plugin : JavaPlugin> : ContextProvider<Plugin, Context<Plugin>>() {
+    override fun create(
+        ctx: CommandContext<CommandSourceStack>,
+        arguments: MutableList<Argument<*>>,
+        subcommand: String?
+    ): Context<Plugin> {
+        val builder = Context.Builder<Plugin>();
+
+        process(builder, ctx, arguments, subcommand);
+
+        return builder.build(ctx.source, plugin);
+    }
+}

--- a/core/src/main/kotlin/net/sylviameows/kitti/Bootstrap.kt
+++ b/core/src/main/kotlin/net/sylviameows/kitti/Bootstrap.kt
@@ -1,19 +1,14 @@
 package net.sylviameows.kitti
 
-import io.papermc.paper.plugin.bootstrap.BootstrapContext
 import io.papermc.paper.plugin.bootstrap.PluginProviderContext
 import net.sylviameows.kitti.api.KittiAPI
 import net.sylviameows.kitti.api.KittiBootstrapper
 import net.sylviameows.kitti.commands.KittiCommand
 import org.bukkit.plugin.java.JavaPlugin
 
-class Bootstrap : KittiBootstrapper() {
+class Bootstrap : KittiBootstrapper<Core>() {
     init {
         addCommand(KittiCommand())
-    }
-
-    override fun bootstrap(context: BootstrapContext) {
-        super.bootstrap(context)
     }
 
     override fun createPlugin(context: PluginProviderContext): JavaPlugin {
@@ -22,5 +17,9 @@ class Bootstrap : KittiBootstrapper() {
             KittiAPI.Holder.setInstance(instance);
         }
         return instance;
+    }
+
+    override fun plugin(context: PluginProviderContext): Core {
+        return Core();
     }
 }

--- a/core/src/main/kotlin/net/sylviameows/kitti/commands/KittiCommand.kt
+++ b/core/src/main/kotlin/net/sylviameows/kitti/commands/KittiCommand.kt
@@ -4,15 +4,14 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
 import net.sylviameows.kitti.Core
-import net.sylviameows.kitti.api.commands.Command
-import net.sylviameows.kitti.api.commands.Context
+import net.sylviameows.kitti.api.commands.context.Context
 import net.sylviameows.kitti.api.commands.Result
-import org.bukkit.Bukkit
+import net.sylviameows.kitti.api.commands.Command
 
-class KittiCommand : Command {
+class KittiCommand : Command<Core> {
     override val name: String = "kitti"
 
-    override fun execute(context: Context): Result {
+    override fun execute(context: Context<Core>): Result {
         val component = Component.empty().append(
             Component.text("ᴋɪᴛᴛɪ").color(TextColor.color(0xde9deb)),
             Component.space(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 plugin_id=KittiLib
-plugin_version=0.4.0
+plugin_version=0.5.0
 
 minecraft_version=1.21.5
 


### PR DESCRIPTION
## Changes
- Kitti now includes your plugins instance in the Context
- Command, KittiBootstrapper, and Context must now include your plugin as a type variable.
- KittiBootstrapper includes new `#plugin()` function which must be implemented. Simple return your plugins class and you're set!

> [!CAUTION]
> This version is **breaking**, and all projects will need to update to support versions `0.5.0+` due to the change in the bootstrapper and command creation.

## How to Update
Update your bootstrapper to include your plugin instance.
```kts
class PluginBootstrap : KittiBootstrapper<PluginCore>() {
    init {
        // add your plugin classes.
        addCommand(PluginCommand())
    }
    
    override fun plugin(context: PluginProviderContext /* you probably dont have to worry about this */): PluginCore {
        // return your main plugin class.
        return PluginCore();
    }
}
```
Create your commands as you would before.
```kt
class PluginCommand : Command<PluginCore> {
    override val name: String = "command"

    override fun execute(context: Context<PluginCore>): Result {
        // you can now access  your plugin instance for shared data.
        val plugin = context.plugin;
        
        context.sender.sendMessage(Component.text(plugin.name))
        return Result.success()
    }
}
```

More advanced functionality can be obtained by making a custom `Context<Plugin>`, `ContextBuilder`, and `ContextProvider<Plugin, Context<Plugin>>` classes. Useful if you want to add user contexts to the commands (e.g. team data, balance, etc.) that are used across many of your commands.

## Whats next?
Commands are still missing aliases, which will be worked on in a future PR.